### PR TITLE
Use logger instead of print

### DIFF
--- a/NeuronLayers.py
+++ b/NeuronLayers.py
@@ -3,6 +3,9 @@ from BDDConn import BDDendriticConnection
 from LateralConn import LateralConnection
 import cupy as cp
 from cupy import sparse
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class NeuronLayer:
@@ -135,7 +138,7 @@ class L2Layer(NeuronLayer):
             active_neurons = cp.logical_and(self.ff_activity, supported_neurons)
             segment_candidates = active_neurons - supported_neurons_mask
             segment_candidates = cp.clip(segment_candidates, 0, 1)
-            print('segment candidates are = ', cp.sum(segment_candidates))
+            logger.debug('Segment candidates: %s', cp.sum(segment_candidates))
             for lclayer in self.lc_layers:
                 lclayer.create_distal_segments(segment_candidates)
             for bdlayer in self.bdd_layers:


### PR DESCRIPTION
## Summary
- import the logging module
- add a module-level logger
- replace a debug `print` statement with a logging call

## Testing
- `python -m py_compile NeuronLayers.py`
- `python -m py_compile *.py Old/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685de3d6d9cc832b9ec352eb09355c88