### PR TITLE
Pass previous predictions into TM learning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 develop-eggs/
 dist/
 downloads/
+runs/
 eggs/
 .eggs/
 lib/

--- a/config.py
+++ b/config.py
@@ -35,6 +35,8 @@ class RunConfig:
     annotate_formulas: bool = True
     per_input_plots_cells: bool = True
     per_input_plots_columns: bool = True
+    diagnostics_print: bool = True
+    sp_near_threshold_eps: float = 0.01
     output_dir: str = "runs"
     run_name: Optional[str] = None
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,16 @@
 
-from dataclasses import dataclass, asdict
-from typing import Optional
+from dataclasses import dataclass, asdict, field
+from typing import Optional, List, Dict
+
+@dataclass
+class MetaParams:
+    enabled: bool = False
+    rungs: List[float] = field(default_factory=lambda: [0.30, 0.40, 0.50])
+    rung_min_margin: Dict[float, int] = field(default_factory=lambda: {0.30: 0, 0.40: 2, 0.50: 4})
+    rung_max_entropy: Dict[float, int] = field(default_factory=lambda: {0.30: 999, 0.40: 2, 0.50: 1})
+    decay_beta: float = 2.0
+    decay_floor: float = 0.10
+    eps: float = 1e-6
 
 @dataclass
 class ModelConfig:
@@ -25,6 +35,7 @@ class ModelConfig:
     segment_activation_threshold: int = 10
     new_segment_init_perm_mean: float = 0.26
     new_segment_init_perm_sd: float = 0.02
+    meta: MetaParams = field(default_factory=MetaParams)
 
 @dataclass
 class RunConfig:

--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ class RunConfig:
     steps: int = 400
     learn: bool = True
     figure_mode: str = "single"  # "single" or "dashboard"
+    annotate_formulas: bool = True
     output_dir: str = "runs"
     run_name: Optional[str] = None
 

--- a/config.py
+++ b/config.py
@@ -33,6 +33,8 @@ class RunConfig:
     learn: bool = True
     figure_mode: str = "single"  # "single" or "dashboard"
     annotate_formulas: bool = True
+    per_input_plots_cells: bool = True
+    per_input_plots_columns: bool = True
     output_dir: str = "runs"
     run_name: Optional[str] = None
 

--- a/htm_core.py
+++ b/htm_core.py
@@ -143,8 +143,25 @@ class TemporalMemory:
               active_cells_prev: Set[int],
               active_columns: np.ndarray,
               active_cells: Set[int],
-              active_segments: Dict[int, List[Segment]]):
-        predicted_cols = {cell // self.cfg.cells_per_column for cell in active_cells}
+              active_segments: Dict[int, List[Segment]],
+              predictive_prev: Set[int]):
+        """Update synapses based on activity at the current timestep.
+
+        Parameters
+        ----------
+        active_cells_prev : Set[int]
+            Cells active at t−1.
+        active_columns : np.ndarray
+            Columns that won inhibition at t.
+        active_cells : Set[int]
+            Cells active at t after applying predictions (non-bursting cells suppressed).
+        active_segments : Dict[int, List[Segment]]
+            Segments that were active at t.
+        predictive_prev : Set[int]
+            Cells that were predicted for t based on state at t−1. Used to
+            determine which columns were truly predicted versus bursting.
+        """
+        predicted_cols = {cell // self.cfg.cells_per_column for cell in predictive_prev}
         bursting_cols = set(active_columns) - predicted_cols
 
         for cell_id, segs in active_segments.items():

--- a/metaplasticity.py
+++ b/metaplasticity.py
@@ -1,0 +1,38 @@
+import numpy as np
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional
+
+@dataclass
+class MetaParams:
+    enabled: bool = False
+    rungs: List[float] = field(default_factory=lambda: [0.30, 0.40, 0.50])
+    rung_min_margin: Dict[float, int] = field(default_factory=lambda: {0.30: 0, 0.40: 2, 0.50: 4})
+    rung_max_entropy: Dict[float, int] = field(default_factory=lambda: {0.30: 999, 0.40: 2, 0.50: 1})
+    decay_beta: float = 2.0
+    decay_floor: float = 0.10
+    eps: float = 1e-6
+
+def effective_dec(perms: np.ndarray, base_dec: float, params: MetaParams) -> np.ndarray:
+    g = np.exp(-params.decay_beta * perms)
+    g = np.maximum(g, params.decay_floor)
+    return base_dec * g
+
+def next_rung(p: float, rungs: List[float]) -> Optional[float]:
+    for r in rungs:
+        if p < r:
+            return r
+    return None
+
+def apply_gates(perms: np.ndarray, inc_try: np.ndarray, margin: float, entropy: int, params: MetaParams) -> np.ndarray:
+    out = inc_try.copy()
+    for i, p in enumerate(perms):
+        r = next_rung(p, params.rungs)
+        if r is None:
+            continue
+        min_margin = params.rung_min_margin.get(r, 0)
+        max_ent = params.rung_max_entropy.get(r, 999)
+        if margin < min_margin or entropy > max_ent:
+            target = r - params.eps
+            if p + out[i] >= target:
+                out[i] = max(0.0, target - p)
+    return out

--- a/metrics.py
+++ b/metrics.py
@@ -65,7 +65,12 @@ class MetricsCollector:
                  input_seen_global: int,
                  active_cells: Set[int],
                  active_columns: Set[int],
-                 predicted_prev: Set[int]):
+                 predicted_prev: Set[int],
+                 kth_overlap: Optional[float] = None,
+                 kplus1_overlap: Optional[float] = None,
+                 k_margin: Optional[float] = None,
+                 sp_connected_mean: Optional[float] = None,
+                 sp_near_thr_frac: Optional[float] = None):
         tp = active_cells & predicted_prev
         fp = predicted_prev - active_cells
         fn = active_cells - predicted_prev
@@ -130,6 +135,11 @@ class MetricsCollector:
             "diff_last_cells": diff_last_cells,
             "overlap_last_cols": overlap_last_cols,
             "diff_last_cols": diff_last_cols,
+            "kth_overlap": kth_overlap,
+            "kplus1_overlap": kplus1_overlap,
+            "k_margin": k_margin,
+            "sp_connected_mean": sp_connected_mean,
+            "sp_near_thr_frac": sp_near_thr_frac,
         }
         self.rows.append(row)
 
@@ -143,6 +153,7 @@ class MetricsCollector:
         self.stability.history[inp_id].append(set(active_cells))
 
         self.sparse_indices["active_cells"].append(np.fromiter(active_cells, dtype=np.int32))
+        self.sparse_indices["active_columns"].append(np.fromiter(active_columns, dtype=np.int32))
         self.sparse_indices["predicted_prev"].append(np.fromiter(predicted_prev, dtype=np.int32))
         self.sparse_indices["tp"].append(np.fromiter(tp, dtype=np.int32))
         self.sparse_indices["fp"].append(np.fromiter(fp, dtype=np.int32))

--- a/plotting.py
+++ b/plotting.py
@@ -1,35 +1,147 @@
 
-import os
+import os, json
 import pandas as pd
 import matplotlib.pyplot as plt
+
+METRIC_NOTES = {
+    "active_cells": "|A_t|",
+    "predicted_cells": "|Pred_{t-1}|",
+    "tp": "|A_t ∩ Pred_{t-1}|",
+    "fp": "|Pred_{t-1} \\ A_t|",
+    "fn": "|A_t \\ Pred_{t-1}|",
+    "precision": "tp / (tp + fp)\n(0 if denom = 0)",
+    "recall": "tp / (tp + fn)\n(0 if denom = 0)",
+    "f1": "2 * precision * recall\n/ (precision + recall)\n(0 if denom = 0)",
+    "active_columns": "|C_t|",
+    "bursting_columns": "|C_t \\ PredCols_{t-1}|,\nPredCols_{t-1} = {col(c): c ∈ Pred_{t-1}}",
+    "sparsity_cells": "|A_t| / {N_cells}",
+    "sparsity_columns": "|C_t| / {N_cols}",
+    "stability_overlap_last": "|A_t ∩ A_last(x)|",
+    "stability_jaccard_last": "J(A_t, A_last(x))",
+    "stability_jaccard_ema": "J(A_t, EMA_x)",
+    "stability_best_window": "max_{i∈last W} J(A_t, A_prev^i(x))",
+    "stability_worst_window": "min_{i∈last W} J(A_t, A_prev^i(x))",
+    "converged": "1 if J(A_t, EMA_x) ≥ τ\nfor M sightings\n(τ={tau}, M={M})",
+}
+
+def annotate(ax, metric_name, model_cfg_dict, run_cfg_dict):
+    note = METRIC_NOTES.get(metric_name)
+    if not note:
+        return
+    fmt = {}
+    if model_cfg_dict:
+        n_cols = model_cfg_dict.get("num_columns")
+        cpc = model_cfg_dict.get("cells_per_column")
+        if n_cols is not None:
+            fmt["N_cols"] = n_cols
+        if n_cols is not None and cpc is not None:
+            fmt["N_cells"] = n_cols * cpc
+    if run_cfg_dict:
+        tau = run_cfg_dict.get("convergence_tau")
+        M = run_cfg_dict.get("convergence_M")
+        if tau is not None:
+            fmt["tau"] = tau
+        if M is not None:
+            fmt["M"] = M
+    try:
+        note = note.format(**fmt)
+    except Exception:
+        pass
+    y = 0.99 - 0.12 * len(ax.texts)
+    ax.text(
+        0.01,
+        y,
+        note,
+        transform=ax.transAxes,
+        va="top",
+        ha="left",
+        fontsize=8,
+        bbox={"boxstyle": "round", "alpha": 0.2},
+    )
 
 def _ensure_dir(d):
     os.makedirs(d, exist_ok=True)
 
-def plot_single_metric_figures(csv_path: str, outdir: str):
+def plot_single_metric_figures(
+    csv_path: str,
+    outdir: str,
+    annotate_formulas: bool = False,
+    model_cfg: dict | None = None,
+    run_cfg: dict | None = None,
+):
     _ensure_dir(outdir)
     df = pd.read_csv(csv_path)
     idx = df["step"] if "step" in df.columns else range(len(df))
 
-    for col in ["active_cells", "predicted_cells", "tp", "fp", "fn",
-                "precision", "recall", "f1",
-                "sparsity_cells", "sparsity_columns",
-                "stability_jaccard_last", "stability_jaccard_ema",
-                "stability_best_window", "stability_worst_window",
-                "bursting_columns"]:
-        if col not in df.columns: continue
+    cfg_dir = os.path.dirname(csv_path)
+    if model_cfg is None:
+        try:
+            with open(os.path.join(cfg_dir, "config_model.json")) as f:
+                model_cfg = json.load(f)
+        except Exception:
+            model_cfg = None
+    if run_cfg is None:
+        try:
+            with open(os.path.join(cfg_dir, "config_run.json")) as f:
+                run_cfg = json.load(f)
+        except Exception:
+            run_cfg = None
+
+    cols = [
+        "active_cells",
+        "predicted_cells",
+        "tp",
+        "fp",
+        "fn",
+        "precision",
+        "recall",
+        "f1",
+        "sparsity_cells",
+        "sparsity_columns",
+        "stability_jaccard_last",
+        "stability_jaccard_ema",
+        "stability_best_window",
+        "stability_worst_window",
+        "bursting_columns",
+    ]
+    for col in cols:
+        if col not in df.columns:
+            continue
         plt.figure()
-        plt.plot(idx, df[col])
-        plt.xlabel("step")
-        plt.ylabel(col)
-        plt.title(col)
+        ax = plt.gca()
+        ax.plot(idx, df[col])
+        ax.set_xlabel("step")
+        ax.set_ylabel(col)
+        ax.set_title(col)
+        if annotate_formulas:
+            annotate(ax, col, model_cfg, run_cfg)
         plt.tight_layout()
         plt.savefig(os.path.join(outdir, f"{col}.png"))
         plt.close()
 
-def plot_dashboard(csv_path: str, outpath: str):
+def plot_dashboard(
+    csv_path: str,
+    outpath: str,
+    annotate_formulas: bool = False,
+    model_cfg: dict | None = None,
+    run_cfg: dict | None = None,
+):
     df = pd.read_csv(csv_path)
     idx = df["step"] if "step" in df.columns else range(len(df))
+
+    cfg_dir = os.path.dirname(csv_path)
+    if model_cfg is None:
+        try:
+            with open(os.path.join(cfg_dir, "config_model.json")) as f:
+                model_cfg = json.load(f)
+        except Exception:
+            model_cfg = None
+    if run_cfg is None:
+        try:
+            with open(os.path.join(cfg_dir, "config_run.json")) as f:
+                run_cfg = json.load(f)
+        except Exception:
+            run_cfg = None
 
     metrics = [
         ("active vs predicted", ["active_cells", "predicted_cells", "tp"]),
@@ -40,13 +152,16 @@ def plot_dashboard(csv_path: str, outpath: str):
     base = os.path.splitext(outpath)[0]
     for title, cols in metrics:
         plt.figure()
+        ax = plt.gca()
         for c in cols:
             if c in df.columns:
-                plt.plot(idx, df[c], label=c)
-        plt.xlabel("step")
-        plt.ylabel(title)
-        plt.legend()
-        plt.title(title)
+                ax.plot(idx, df[c], label=c)
+                if annotate_formulas:
+                    annotate(ax, c, model_cfg, run_cfg)
+        ax.set_xlabel("step")
+        ax.set_ylabel(title)
+        ax.legend()
+        ax.set_title(title)
         plt.tight_layout()
         plt.savefig(f"{base}_{title.replace(' ', '_')}.png")
         plt.close()

--- a/run.py
+++ b/run.py
@@ -4,6 +4,7 @@ import numpy as np
 from typing import Dict, List, Set
 from datetime import datetime
 from itertools import combinations
+from dataclasses import asdict
 
 from config import ModelConfig, RunConfig, json_dumps
 from metrics import MetricsCollector
@@ -49,9 +50,9 @@ def main(model_cfg: ModelConfig, run_cfg: RunConfig):
     run_name = run_cfg.run_name or "htm_np"
     outdir = make_run_dir(run_cfg.output_dir, run_name)
     with open(os.path.join(outdir, "config_model.json"), "w") as f:
-        f.write(json_dumps(model_cfg.__dict__))
+        f.write(json_dumps(asdict(model_cfg)))
     with open(os.path.join(outdir, "config_run.json"), "w") as f:
-        f.write(json_dumps(run_cfg.__dict__))
+        f.write(json_dumps(asdict(run_cfg)))
 
     sp = SpatialPooler.create(model_cfg, rng)
     tm = TemporalMemory.create(model_cfg, rng)
@@ -226,7 +227,11 @@ def main(model_cfg: ModelConfig, run_cfg: RunConfig):
                     f"{tok}: pred={row['predicted_cells']:.3f}, burst={row['bursting_columns']:.3f}, "
                     f"prec={row['precision']:.3f}, rec={row['recall']:.3f}"
                 )
-
+    if model_cfg.meta.enabled:
+        print(
+            f"Metaplasticity: rungs={model_cfg.meta.rungs}, "
+            f"decay_beta={model_cfg.meta.decay_beta}, decay_floor={model_cfg.meta.decay_floor}"
+        )
     print("Run complete. Outputs in:", outdir)
     return outdir
 

--- a/run.py
+++ b/run.py
@@ -6,7 +6,11 @@ from datetime import datetime
 
 from config import ModelConfig, RunConfig, json_dumps
 from metrics import MetricsCollector
-from plotting import plot_single_metric_figures, plot_dashboard
+from plotting import (
+    plot_single_metric_figures,
+    plot_dashboard,
+    plot_per_input_phasefold,
+)
 from htm_core import SpatialPooler, TemporalMemory, seeded_rng, active_cells_prev_global
 
 def make_run_dir(base: str, run_name: str) -> str:
@@ -54,7 +58,8 @@ def main(model_cfg: ModelConfig, run_cfg: RunConfig):
     token_map = build_inputs(rng, run_cfg, model_cfg)
     tokens = run_cfg.sequence.split(run_cfg.sequence_delimiter)
     metrics = MetricsCollector(
-        num_cells=model_cfg.num_columns*model_cfg.cells_per_column,
+        num_cells=model_cfg.num_columns * model_cfg.cells_per_column,
+        cells_per_column=model_cfg.cells_per_column,
         output_dir=outdir,
         run_name=run_name,
         ema_threshold=run_cfg.ema_threshold,
@@ -124,6 +129,11 @@ def main(model_cfg: ModelConfig, run_cfg: RunConfig):
         plot_single_metric_figures(
             saved["csv"], plots_dir, annotate_formulas=run_cfg.annotate_formulas
         )
+
+    if run_cfg.per_input_plots_cells:
+        plot_per_input_phasefold(saved["csv"], plots_dir, what="cells")
+    if run_cfg.per_input_plots_columns:
+        plot_per_input_phasefold(saved["csv"], plots_dir, what="columns")
 
     print("Run complete. Outputs in:", outdir)
     return outdir

--- a/run.py
+++ b/run.py
@@ -100,7 +100,7 @@ def main(model_cfg: ModelConfig, run_cfg: RunConfig):
 
         if run_cfg.learn:
             sp.learn(dense_inp, active_cols)
-            tm.learn(active_cells_prev_global, active_cols, active_cells, active_segments)
+            tm.learn(active_cells_prev_global, active_cols, active_cells, active_segments, predictive_cells)
 
         predicted_prev = tm.compute_predictive_cells(active_cells)
         active_cells_prev_global = set(active_cells)

--- a/run.py
+++ b/run.py
@@ -8,6 +8,7 @@ from dataclasses import asdict
 
 from config import ModelConfig, RunConfig, json_dumps
 from metrics import MetricsCollector
+from metaplasticity import MetaParams
 from plotting import (
     plot_single_metric_figures,
     plot_dashboard,
@@ -241,11 +242,12 @@ if __name__ == "__main__":
         num_columns=2048,
         cells_per_column=10,
         k_active_columns=40,
-        synapses_per_column=32,
+        synapses_per_column=64,
         perm_connected=0.25,
         init_perm_mean=0.26,
         init_perm_sd=0.02,
         perm_inc=0.03,
+        meta=MetaParams(enabled=False),
         perm_dec=0.015,
         distal_synapses_per_segment=20,
         segment_activation_threshold=10,

--- a/run.py
+++ b/run.py
@@ -111,11 +111,19 @@ def main(model_cfg: ModelConfig, run_cfg: RunConfig):
     saved = metrics.finalize()
     plots_dir = os.path.join(outdir, "plots"); os.makedirs(plots_dir, exist_ok=True)
     if run_cfg.figure_mode == "single":
-        plot_single_metric_figures(saved["csv"], plots_dir)
+        plot_single_metric_figures(
+            saved["csv"], plots_dir, annotate_formulas=run_cfg.annotate_formulas
+        )
     elif run_cfg.figure_mode == "dashboard":
-        plot_dashboard(saved["csv"], os.path.join(plots_dir, "dashboard.png"))
+        plot_dashboard(
+            saved["csv"],
+            os.path.join(plots_dir, "dashboard.png"),
+            annotate_formulas=run_cfg.annotate_formulas,
+        )
     else:
-        plot_single_metric_figures(saved["csv"], plots_dir)
+        plot_single_metric_figures(
+            saved["csv"], plots_dir, annotate_formulas=run_cfg.annotate_formulas
+        )
 
     print("Run complete. Outputs in:", outdir)
     return outdir


### PR DESCRIPTION
## Summary
- Extend `TemporalMemory.learn` to accept previous-step predicted cells
- Calculate bursting columns from previous predictions and document learning arguments
- Update `run.py` to pass predicted cells into the learning step

## Testing
- `python _tiny_run.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d2a95b88832b8f88e6a62d50e230