### PR TITLE
Add plot for active vs predicted neurons

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Outputs:
 - `runs/<timestamp>_starter/indices.npz` — sparse indices (active, predicted_prev, tp/fp/fn)
 - `runs/<timestamp>_starter/plots/` — baseline instrumentation charts, including
   encoding stability per sequence step (cycle vs. Jaccard distance to the prior
-  occurrence of that input)
+  occurrence of that input) and active vs. predicted neuron counts per timestep
 
 Tune config in `config.py` / `run.py`. Change sparsity or permanence thresholds easily.
 Optional: `pip install torch` and set `RunConfig(backend="torch", device="cuda")` to run the Spatial Pooler on GPU.

--- a/plotting.py
+++ b/plotting.py
@@ -110,6 +110,20 @@ def plot_baseline_meta(csv_path: str, outdir: str):
         plt.savefig(os.path.join(outdir, "prediction_accuracy.png"))
         plt.close()
 
+    if "predicted_cells" in df.columns or "active_cells" in df.columns:
+        plt.figure()
+        if "predicted_cells" in df.columns:
+            plt.plot(idx, df["predicted_cells"], label="predicted")
+        if "active_cells" in df.columns:
+            plt.plot(idx, df["active_cells"], label="active")
+        plt.xlabel("step")
+        plt.ylabel("cells")
+        plt.title("Active vs. predicted cells")
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(os.path.join(outdir, "active_vs_predicted_cells.png"))
+        plt.close()
+
     if "segments" in df.columns or "synapses" in df.columns:
         plt.figure()
         if "segments" in df.columns:
@@ -200,6 +214,21 @@ def plot_baseline_meta_sweep(csv_paths, labels, outdir):
         plt.legend()
         plt.tight_layout()
         plt.savefig(os.path.join(outdir, "prediction_accuracy.png"))
+        plt.close()
+
+    if any_col("predicted_cells") or any_col("active_cells"):
+        plt.figure()
+        for df, idx, label in zip(dfs, idxs, kept_labels):
+            if "predicted_cells" in df.columns:
+                plt.plot(idx, df["predicted_cells"], label=f"{label}-pred")
+            if "active_cells" in df.columns:
+                plt.plot(idx, df["active_cells"], label=f"{label}-active")
+        plt.xlabel("step")
+        plt.ylabel("cells")
+        plt.title("Active vs. predicted cells (all runs)")
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(os.path.join(outdir, "active_vs_predicted_cells.png"))
         plt.close()
 
     if any_col("segments") or any_col("synapses"):


### PR DESCRIPTION
## Summary
- plot active and predicted neuron counts in baseline meta plots
- show active vs predicted neuron lines in sweep plots
- document new plot in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a936cc9a6c832b9b9c046e25ce2e64